### PR TITLE
Fix GitHub Actions Authentication Issues

### DIFF
--- a/.github/workflows/bumpversion.yml
+++ b/.github/workflows/bumpversion.yml
@@ -10,14 +10,15 @@ jobs:
     if: "!startsWith(github.event.head_commit.message, 'bump:')"
     runs-on: ubuntu-latest
     name: "Bump version and create changelog with commitizen"
+    permissions:
+      contents: write
     steps:
       - name: Check out
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           fetch-depth: 0
-          token: '${{ secrets.PERSONAL_ACCESS_TOKEN }}'
       - name: Create bump and changelog
         uses: commitizen-tools/commitizen-action@master
         with:
-          github_token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+          github_token: ${{ github.token }}
           branch: main

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -60,7 +60,7 @@ jobs:
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         uses: peaceiris/actions-gh-pages@v4
         with:
-          github_token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+          github_token: ${{ github.token }}
           publish_dir: ./docs/build/html
           keep_files: true  # Keep previously deployed files
           enable_jekyll: false  # Disable Jekyll processing

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -42,7 +42,7 @@ jobs:
       id: changelog
       uses: jaywcjlove/changelog-generator@main
       with:
-        token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+        token: ${{ github.token }}
         filter-author: (|dependabot|renovate\\[bot\\]|dependabot\\[bot\\]|Renovate Bot)
         filter: '[R|r]elease[d]\s+[v|V]\d(\.\d+){0,2}'
         template: |
@@ -59,7 +59,7 @@ jobs:
     - uses: ncipollo/release-action@v1
       with:
         artifacts: "dist/*"
-        token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+        token: ${{ github.token }}
         body: |
           Comparing Changes: ${{ steps.changelog.outputs.compareurl }}
 


### PR DESCRIPTION
## Description

This PR fixes the GitHub Actions authentication issues by replacing `PERSONAL_ACCESS_TOKEN` with `github.token` in all workflow files.

## Changes

- Updated `bumpversion.yml` to use `github.token` and added proper permissions
- Updated `docs.yml` to use `github.token` for GitHub Pages deployment
- Updated `python-publish.yml` to use `github.token` for changelog generation and release creation

## Problem Solved

This fixes the error: "could not read Username for 'https://github.com': terminal prompts disabled" that occurred during the "Bump version and create changelog with commitizen" action.

## Benefits

- No need to manually manage personal access tokens
- Follows security best practices by using the built-in token
- Simplifies workflow configuration

## Testing

After merging, the automated version bumping should work correctly when commits are pushed to the main branch.