### PR TITLE
Fix GitHub Actions Workflow for Tag Publishing

### DIFF
--- a/.github/workflows/bumpversion.yml
+++ b/.github/workflows/bumpversion.yml
@@ -45,4 +45,4 @@ jobs:
         with:
           token: ${{ github.token }}
           event-type: trigger-python-publish
-          client-payload: '{"tag": "v${{ steps.cz.outputs.version }}"}'
+          client-payload: '{"tag": "v${{ steps.cz.outputs.version }}", "version": "${{ steps.cz.outputs.version }}"}'

--- a/.github/workflows/bumpversion.yml
+++ b/.github/workflows/bumpversion.yml
@@ -12,13 +12,37 @@ jobs:
     name: "Bump version and create changelog with commitizen"
     permissions:
       contents: write
+      # Allow the job to create workflow runs
+      actions: write
     steps:
       - name: Check out
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           fetch-depth: 0
+          token: ${{ github.token }}
       - name: Create bump and changelog
+        id: cz
         uses: commitizen-tools/commitizen-action@master
         with:
           github_token: ${{ github.token }}
           branch: main
+      - name: Print version
+        run: echo "Bumped to version ${{ steps.cz.outputs.version }}"
+      - name: Push tag explicitly
+        if: steps.cz.outputs.version != ''
+        run: |
+          echo "Creating and pushing tag v${{ steps.cz.outputs.version }}"
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+          git tag -f v${{ steps.cz.outputs.version }}
+          git push origin v${{ steps.cz.outputs.version }} --force
+          echo "Tag pushed successfully"
+          git tag -l
+
+      - name: Trigger python-publish workflow
+        if: steps.cz.outputs.version != ''
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ github.token }}
+          event-type: trigger-python-publish
+          client-payload: '{"tag": "v${{ steps.cz.outputs.version }}"}'

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -21,9 +21,11 @@ jobs:
       run: |
         if [[ "${{ github.event_name }}" == "repository_dispatch" ]]; then
           echo "TAG=${{ github.event.client_payload.tag }}" >> $GITHUB_ENV
+          echo "VERSION=${{ github.event.client_payload.version }}" >> $GITHUB_ENV
           echo "Using tag from repository_dispatch: ${{ github.event.client_payload.tag }}"
         else
           echo "TAG=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
+          echo "VERSION=${GITHUB_REF#refs/tags/v}" >> $GITHUB_ENV
           echo "Using tag from push event: ${GITHUB_REF#refs/tags/}"
         fi
 

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -4,6 +4,8 @@ on:
   push:
     tags:
       - "v*"
+  repository_dispatch:
+    types: [trigger-python-publish]
 
 jobs:
   deploy:
@@ -14,9 +16,20 @@ jobs:
       contents: write
 
     steps:
+    - name: Set tag variable
+      id: set_tag
+      run: |
+        if [[ "${{ github.event_name }}" == "repository_dispatch" ]]; then
+          echo "TAG=${{ github.event.client_payload.tag }}" >> $GITHUB_ENV
+          echo "Using tag from repository_dispatch: ${{ github.event.client_payload.tag }}"
+        else
+          echo "TAG=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
+          echo "Using tag from push event: ${GITHUB_REF#refs/tags/}"
+        fi
+
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       with:
-        token: "${{ secrets.GITHUB_TOKEN }}"
+        token: "${{ github.token }}"
         fetch-depth: 0
         ref: main
     - uses: olegtarasov/get-tag@v2.1.4


### PR DESCRIPTION
## Description

This PR fixes the issue where tag creation doesn't trigger the expected python-publish.yml workflow. The changes ensure that when a new version is bumped and a tag is created, the Python package is properly published to PyPI.

## Changes

1. Enhanced the bumpversion.yml workflow to:
   - Add explicit tag pushing with proper git configuration
   - Add repository_dispatch event to trigger the python-publish workflow
   - Add debugging output for better troubleshooting

2. Modified the python-publish.yml workflow to:
   - Respond to both tag push events and repository_dispatch events
   - Handle tag information correctly from both event types
   - Add version variable extraction for better flexibility

## Testing

These changes will be tested when merged to main branch, as they specifically address the workflow that runs on tag creation after merging to main.