### PR TITLE
Fix release-action tag error in GitHub Actions workflow

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -22,12 +22,27 @@ jobs:
         if [[ "${{ github.event_name }}" == "repository_dispatch" ]]; then
           echo "TAG=${{ github.event.client_payload.tag }}" >> $GITHUB_ENV
           echo "VERSION=${{ github.event.client_payload.version }}" >> $GITHUB_ENV
+          echo "RELEASE_TAG=${{ github.event.client_payload.tag }}" >> $GITHUB_ENV
           echo "Using tag from repository_dispatch: ${{ github.event.client_payload.tag }}"
         else
           echo "TAG=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
           echo "VERSION=${GITHUB_REF#refs/tags/v}" >> $GITHUB_ENV
+          echo "RELEASE_TAG=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
           echo "Using tag from push event: ${GITHUB_REF#refs/tags/}"
         fi
+
+        # Fallback for tag if environment variables are not available
+        if [[ -z "$TAG" ]]; then
+          echo "TAG not set, using GITHUB_REF directly"
+          REF_TAG=${GITHUB_REF#refs/tags/}
+          echo "RELEASE_TAG=$REF_TAG" >> $GITHUB_ENV
+        fi
+
+    - name: Debug environment variables
+      run: |
+        echo "TAG: ${{ env.TAG }}"
+        echo "VERSION: ${{ env.VERSION }}"
+        echo "GITHUB_REF: ${{ github.ref }}"
 
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       with:
@@ -53,6 +68,13 @@ jobs:
       uses: pypa/gh-action-pypi-publish@release/v1
       with:
         packages-dir: dist
+    - name: Debug tag information
+      run: |
+        echo "GITHUB_REF: ${{ github.ref }}"
+        echo "TAG env: ${{ env.TAG }}"
+        echo "VERSION env: ${{ env.VERSION }}"
+        echo "RELEASE_TAG env: ${{ env.RELEASE_TAG }}"
+
     - name: Generate changelog
       id: changelog
       uses: jaywcjlove/changelog-generator@main
@@ -71,10 +93,21 @@ jobs:
           {{chore,style,ci||🔶 Nothing change}}
           ## Unknown
           {{__unknown__}}
+    # Extract tag from ref as a fallback
+    - name: Extract tag from ref
+      id: get_ref_tag
+      run: |
+        REF_TAG="${GITHUB_REF#refs/tags/}"
+        echo "REF_TAG=$REF_TAG" >> $GITHUB_OUTPUT
+        echo "Extracted tag from ref: $REF_TAG"
+
     - uses: ncipollo/release-action@v1
       with:
         artifacts: "dist/*"
         token: ${{ github.token }}
+        tag: ${{ env.RELEASE_TAG || steps.get_ref_tag.outputs.REF_TAG || github.ref_name }}
+        name: "Release ${{ env.RELEASE_TAG || steps.get_ref_tag.outputs.REF_TAG || github.ref_name }}"
+        allowUpdates: true
         body: |
           Comparing Changes: ${{ steps.changelog.outputs.compareurl }}
 


### PR DESCRIPTION
## Description

This PR fixes the issue where the ncipollo/release-action@v1 step fails with "Error undefined: No tag found in ref or input!" error in the python-publish.yml workflow.

## Changes

1. Added multiple fallback mechanisms for tag detection:
   - Primary: Use environment variable RELEASE_TAG set during the workflow
   - Secondary: Extract tag directly from GITHUB_REF
   - Tertiary: Use github.ref_name context variable

2. Added debug steps to help troubleshoot tag-related issues

3. Added allowUpdates parameter to ensure releases can be updated if they already exist

## Testing

This change will be tested when a new tag is created, ensuring the release action can properly identify the tag and create a release.