### PR TITLE
Fix CLI executable name and release action tag issues

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -93,20 +93,36 @@ jobs:
           {{chore,style,ci||🔶 Nothing change}}
           ## Unknown
           {{__unknown__}}
-    # Extract tag from ref as a fallback
-    - name: Extract tag from ref
-      id: get_ref_tag
+    # Extract tag from ref as a fallback and set final tag
+    - name: Set final tag for release
+      id: set_final_tag
       run: |
-        REF_TAG="${GITHUB_REF#refs/tags/}"
-        echo "REF_TAG=$REF_TAG" >> $GITHUB_OUTPUT
-        echo "Extracted tag from ref: $REF_TAG"
+        # Try to get tag from environment variables first
+        if [[ -n "${{ env.RELEASE_TAG }}" ]]; then
+          FINAL_TAG="${{ env.RELEASE_TAG }}"
+          echo "Using RELEASE_TAG: $FINAL_TAG"
+        elif [[ -n "${{ env.TAG }}" ]]; then
+          FINAL_TAG="${{ env.TAG }}"
+          echo "Using TAG: $FINAL_TAG"
+        elif [[ "${{ github.ref }}" == refs/tags/* ]]; then
+          FINAL_TAG="${GITHUB_REF#refs/tags/}"
+          echo "Using GITHUB_REF: $FINAL_TAG"
+        else
+          FINAL_TAG="${{ github.ref_name }}"
+          echo "Using github.ref_name: $FINAL_TAG"
+        fi
+
+        # Set output and environment variable
+        echo "FINAL_TAG=$FINAL_TAG" >> $GITHUB_OUTPUT
+        echo "FINAL_TAG=$FINAL_TAG" >> $GITHUB_ENV
+        echo "Final tag for release: $FINAL_TAG"
 
     - uses: ncipollo/release-action@v1
       with:
         artifacts: "dist/*"
         token: ${{ github.token }}
-        tag: ${{ env.RELEASE_TAG || steps.get_ref_tag.outputs.REF_TAG || github.ref_name }}
-        name: "Release ${{ env.RELEASE_TAG || steps.get_ref_tag.outputs.REF_TAG || github.ref_name }}"
+        tag: ${{ steps.set_final_tag.outputs.FINAL_TAG }}
+        name: "Release ${{ steps.set_final_tag.outputs.FINAL_TAG }}"
         allowUpdates: true
         body: |
           Comparing Changes: ${{ steps.changelog.outputs.compareurl }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ click = ">=8.1.0"
 
 [tool.poetry.scripts]
 persistent_ssh_agent = "persistent_ssh_agent.cli:main"
+persistent-ssh-agent = "persistent_ssh_agent.cli:main"
 
 [tool.poetry.group.docs.dependencies]
 sphinx = ">=8.0"


### PR DESCRIPTION
## Description

This PR fixes two issues:

1. CLI executable name issue: When users run `uvx persistent-ssh-agent`, they get an error that the executable is not found. This PR adds a hyphenated script name in pyproject.toml to support both formats.

2. Release action tag issue: The `ncipollo/release-action@v1` step fails with "Error undefined: No tag found in ref or input!". This PR improves the tag detection logic to be more robust.

## Changes

1. Added hyphenated script name in pyproject.toml:
   ```toml
   [tool.poetry.scripts]
   persistent_ssh_agent = "persistent_ssh_agent.cli:main"
   persistent-ssh-agent = "persistent_ssh_agent.cli:main"
   ```

2. Improved tag detection in GitHub Actions workflow:
   - Added a dedicated step to determine the final tag to use
   - Implemented a clear fallback chain for tag detection
   - Used step outputs instead of environment variables for more reliable access

## Testing

The CLI executable name change can be tested by installing the package and running both `uvx persistent_ssh_agent` and `uvx persistent-ssh-agent`.

The release action tag fix will be tested when a new tag is created.